### PR TITLE
Add item drops to bats; reduce scientist drops

### DIFF
--- a/Assets/Prefabs/Enemies/Bat/Bat_1.prefab
+++ b/Assets/Prefabs/Enemies/Bat/Bat_1.prefab
@@ -105,6 +105,7 @@ GameObject:
   - component: {fileID: 1833444578074242281}
   - component: {fileID: 3764929845417665654}
   - component: {fileID: 1533490436633091552}
+  - component: {fileID: 3903707393797142135}
   m_Layer: 8
   m_Name: Bat_1
   m_TagString: Enemy
@@ -272,6 +273,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EntityEffectsSystem
   entity: {fileID: 710732635978774089}
+  effectSlotManager: {fileID: 0}
 --- !u!50 &1271088907665360827
 Rigidbody2D:
   serializedVersion: 5
@@ -395,3 +397,18 @@ MonoBehaviour:
   OverrideAttenuation: 1
   OverrideMinDistance: 1
   OverrideMaxDistance: 10
+--- !u!114 &3903707393797142135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3304388756238957270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4752bbcec42df1b46966be8d574653db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropController
+  dropConfig: {fileID: 11400000, guid: 1c160eec805aa2743b66502f91a898bd, type: 2}
+  itemPickupPrefab: {fileID: 6286728296311827303, guid: cad36ec3e785ac042ae7d1c1b7b899ad, type: 3}
+  dropChance: 0.8

--- a/Assets/Prefabs/Enemies/Bat/Bat_2.prefab
+++ b/Assets/Prefabs/Enemies/Bat/Bat_2.prefab
@@ -105,6 +105,7 @@ GameObject:
   - component: {fileID: 3764929845417665654}
   - component: {fileID: 1714250523144505033}
   - component: {fileID: -5081348076499347348}
+  - component: {fileID: -8367398640246500815}
   m_Layer: 8
   m_Name: Bat_2
   m_TagString: Enemy
@@ -272,6 +273,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EntityEffectsSystem
   entity: {fileID: 710732635978774089}
+  effectSlotManager: {fileID: 0}
 --- !u!50 &1271088907665360827
 Rigidbody2D:
   serializedVersion: 5
@@ -395,3 +397,18 @@ MonoBehaviour:
   OverrideAttenuation: 1
   OverrideMinDistance: 1
   OverrideMaxDistance: 10
+--- !u!114 &-8367398640246500815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3304388756238957270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4752bbcec42df1b46966be8d574653db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropController
+  dropConfig: {fileID: 11400000, guid: 1c160eec805aa2743b66502f91a898bd, type: 2}
+  itemPickupPrefab: {fileID: 6286728296311827303, guid: cad36ec3e785ac042ae7d1c1b7b899ad, type: 3}
+  dropChance: 0.8

--- a/Assets/Prefabs/Enemies/Bat/Bat_3.prefab
+++ b/Assets/Prefabs/Enemies/Bat/Bat_3.prefab
@@ -105,6 +105,7 @@ GameObject:
   - component: {fileID: 3764929845417665654}
   - component: {fileID: 8494767211267583048}
   - component: {fileID: 8257812054412205734}
+  - component: {fileID: -4861324830751544881}
   m_Layer: 8
   m_Name: Bat_3
   m_TagString: Enemy
@@ -272,6 +273,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EntityEffectsSystem
   entity: {fileID: 710732635978774089}
+  effectSlotManager: {fileID: 0}
 --- !u!50 &1271088907665360827
 Rigidbody2D:
   serializedVersion: 5
@@ -395,3 +397,18 @@ MonoBehaviour:
   OverrideAttenuation: 1
   OverrideMinDistance: 1
   OverrideMaxDistance: 10
+--- !u!114 &-4861324830751544881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3304388756238957270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4752bbcec42df1b46966be8d574653db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropController
+  dropConfig: {fileID: 11400000, guid: 1c160eec805aa2743b66502f91a898bd, type: 2}
+  itemPickupPrefab: {fileID: 6286728296311827303, guid: cad36ec3e785ac042ae7d1c1b7b899ad, type: 3}
+  dropChance: 0.8

--- a/Assets/Prefabs/Enemy/Complete/Scientist 1.prefab
+++ b/Assets/Prefabs/Enemy/Complete/Scientist 1.prefab
@@ -367,7 +367,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropController
   dropConfig: {fileID: 11400000, guid: 1c160eec805aa2743b66502f91a898bd, type: 2}
   itemPickupPrefab: {fileID: 6286728296311827303, guid: cad36ec3e785ac042ae7d1c1b7b899ad, type: 3}
-  dropChance: 1
+  dropChance: 0.5
 --- !u!1 &8559998504225684287
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/Complete/Scientist 2.prefab
+++ b/Assets/Prefabs/Enemy/Complete/Scientist 2.prefab
@@ -610,4 +610,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropController
   dropConfig: {fileID: 11400000, guid: 1c160eec805aa2743b66502f91a898bd, type: 2}
   itemPickupPrefab: {fileID: 6286728296311827303, guid: cad36ec3e785ac042ae7d1c1b7b899ad, type: 3}
-  dropChance: 1
+  dropChance: 0.5

--- a/Assets/Prefabs/Enemy/Complete/Scientist 3.prefab
+++ b/Assets/Prefabs/Enemy/Complete/Scientist 3.prefab
@@ -499,7 +499,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropController
   dropConfig: {fileID: 11400000, guid: 1c160eec805aa2743b66502f91a898bd, type: 2}
   itemPickupPrefab: {fileID: 6286728296311827303, guid: cad36ec3e785ac042ae7d1c1b7b899ad, type: 3}
-  dropChance: 1
+  dropChance: 0.5
 --- !u!1 &7405638993240219033
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Attach EntityItemDropController to Bat_1/2/3 prefabs (adds dropConfig, itemPickupPrefab and dropChance=0.8) and add effectSlotManager placeholder to their EntityEffectsSystem entries. Also lower item dropChance from 1 to 0.5 on Scientist 1/2/3 prefabs to reduce drop rates for balance.