### PR TITLE
Add ExtraJump effect & Wings item; tweak movement/sprites

### DIFF
--- a/Assets/Prefabs/Effects/WingsEffect.asset
+++ b/Assets/Prefabs/Effects/WingsEffect.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66238b6b37f97f1439f9bedf6e81cc59, type: 3}
+  m_Name: WingsEffect
+  m_EditorClassIdentifier: Assembly-CSharp::ExtraJumpEffect
+  effectName: "\u041A\u0440\u044B\u043B\u044C\u044F"
+  description: "\u041D\u0430\u0448\u0451\u043B \u0447\u044C\u0438-\u0442\u043E \u043A\u0440\u044B\u043B\u044C\u044F.
+    \u041E\u043D\u0438 \u043F\u043E\u0434\u043E\u0448\u043B\u0438. +1 \u043F\u0440\u044B\u0436\u043E\u043A."
+  icon: {fileID: 0}
+  duration: 9999999
+  extraJumps: 1

--- a/Assets/Prefabs/Effects/WingsEffect.asset.meta
+++ b/Assets/Prefabs/Effects/WingsEffect.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bd90fb1ab3b9804a923693fc6d4b9a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Items/Ready/Green/Amulet.asset
+++ b/Assets/Prefabs/Items/Ready/Green/Amulet.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     \u0434\u0435\u043D\u044C. \u0428\u0430\u043D\u0441 \u043F\u0430\u0434\u0435\u043D\u0438\u044F
     \u043F\u0440\u0435\u0434\u043C\u0435\u0442\u043E\u0432 \u0443\u0432\u0435\u043B\u0438\u0447\u0435\u043D
     \u043D\u0430 10%."
-  icon: {fileID: 0}
+  icon: {fileID: 5647430373762768393, guid: 1882e7e896f145845bb7a60754bad6ca, type: 3}
   rarity: 1
   modifiers:
   - statType: 11

--- a/Assets/Prefabs/Items/Ready/Green/Wings.asset
+++ b/Assets/Prefabs/Items/Ready/Green/Wings.asset
@@ -10,11 +10,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5b9614692ce221545a77a57c30d645af, type: 3}
-  m_Name: Vampirism
+  m_Name: Wings
   m_EditorClassIdentifier: Assembly-CSharp::EffectItemData
-  itemName: "\u0412\u0430\u043C\u043F\u0438\u0440"
-  description: "\u041A\u0443\u0441\u044C. \u0418 \u0442\u0435\u0431\u0435 \u043B\u0443\u0447\u0448\u0435,
-    \u0438 \u043C\u043D\u0435."
-  icon: {fileID: -5147648070511390304, guid: 224e576d8c1b37d489a900062694f7b8, type: 3}
-  rarity: 2
-  effect: {fileID: 11400000, guid: 87c7b235f1e2ff247831d74a5a69f95d, type: 2}
+  itemName: "\u041A\u0440\u044B\u043B\u044C\u044F"
+  description: "\u041D\u0430\u0448\u0451\u043B \u0447\u044C\u0438-\u0442\u043E \u043A\u0440\u044B\u043B\u044C\u044F.
+    \u041E\u043D\u0438 \u043F\u043E\u0434\u043E\u0448\u043B\u0438. +1 \u043F\u0440\u044B\u0436\u043E\u043A."
+  icon: {fileID: 0}
+  rarity: 1
+  effect: {fileID: 11400000, guid: 2bd90fb1ab3b9804a923693fc6d4b9a1, type: 2}

--- a/Assets/Prefabs/Items/Ready/Green/Wings.asset.meta
+++ b/Assets/Prefabs/Items/Ready/Green/Wings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c6a30a6592c713428957144f453e66c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Items/Ready/White/FirstAidKit.asset
+++ b/Assets/Prefabs/Items/Ready/White/FirstAidKit.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
     \u0437\u0434\u043E\u0440\u043E\u0432\u044C\u044F \u043F\u043E\u0441\u043B\u0435
     10 \u0441\u0435\u043A\u0443\u043D\u0434 \u0431\u0435\u0437 \u043F\u043E\u043B\u0443\u0447\u0435\u043D\u0438\u044F
     \u0443\u0440\u043E\u043D\u0430."
-  icon: {fileID: 0}
+  icon: {fileID: -4602829306680624917, guid: 4ed19843bf250a149b6bf0cdf1338621, type: 3}
   rarity: 0
   effect: {fileID: 11400000, guid: b5a41044ecf9c2840b514ec4914b976e, type: 2}

--- a/Assets/Prefabs/Items/Ready/White/SpeedBoots.asset
+++ b/Assets/Prefabs/Items/Ready/White/SpeedBoots.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     \u0434\u0430 \u0435\u0449\u0435 \u0438 \u0443\u0434\u043E\u0431\u043D\u044B\u0435!
     \u0414\u043E\u0431\u0430\u0432\u043B\u044F\u044E\u0442 8% \u043A \u0441\u043A\u043E\u0440\u043E\u0441\u0442\u0438
     \u043F\u0435\u0440\u0435\u0434\u0432\u0438\u0436\u0435\u043D\u0438\u044F."
-  icon: {fileID: 0}
+  icon: {fileID: -7802668924161038262, guid: fa2aed2529308f545bda024cae3e7d15, type: 3}
   rarity: 0
   modifiers:
   - statType: 0

--- a/Assets/Prefabs/Player/Attacks/PlayerMeleeAttack_1.asset
+++ b/Assets/Prefabs/Player/Attacks/PlayerMeleeAttack_1.asset
@@ -20,8 +20,8 @@ MonoBehaviour:
   windupTime: 0.03
   knockbackForce: {x: 12, y: 6}
   knockbackDuration: 0.15
-  hitboxSize: {x: 1.4, y: 1.2}
-  hitboxOffset: {x: 0.8, y: 0}
+  hitboxSize: {x: 2.5, y: 2}
+  hitboxOffset: {x: 0.5, y: 0}
   targetLayers:
     serializedVersion: 2
     m_Bits: 256

--- a/Assets/Scripts/Effects/ExtraJumpEffect.cs
+++ b/Assets/Scripts/Effects/ExtraJumpEffect.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(menuName = "Effects/Extra Jump")]
+public class ExtraJumpEffect : EntityEffectData
+{
+    public byte extraJumps = 1;
+
+    public override void Execute(BaseEntity entity, ActiveEffect activeEffect)
+    {
+        var movement = entity.GetComponent<PlayerMovement>();
+        movement?.AddJump(extraJumps);
+    }
+
+    public override void Remove(BaseEntity entity, ActiveEffect activeEffect)
+    {
+        var movement = entity.GetComponent<PlayerMovement>();
+        movement?.RemoveJump(extraJumps);
+    }
+}

--- a/Assets/Scripts/Effects/ExtraJumpEffect.cs.meta
+++ b/Assets/Scripts/Effects/ExtraJumpEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66238b6b37f97f1439f9bedf6e81cc59

--- a/Assets/Scripts/Items/Configs/Bat.asset
+++ b/Assets/Scripts/Items/Configs/Bat.asset
@@ -10,24 +10,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 57a6888ce27d6b449b6d6ba17e7baec0, type: 3}
-  m_Name: Scientist1
+  m_Name: Bat
   m_EditorClassIdentifier: Assembly-CSharp::EntityItemDropConfig
   whiteItems:
-  - {fileID: 11400000, guid: a4d62b417d49aa349b98d74be4353af5, type: 2}
+  - {fileID: 11400000, guid: 75c5535b65d53964fa74889476cc8845, type: 2}
   - {fileID: 11400000, guid: 26d578b09eaeb7e4a823f70c109c6526, type: 2}
-  - {fileID: 11400000, guid: 6e54397e598f7a44781ad2f88b92934f, type: 2}
-  - {fileID: 11400000, guid: 46b42a69c72730340b9cd78422c18725, type: 2}
+  - {fileID: 11400000, guid: ecd7dcb384c54d14a8ee635fec250d47, type: 2}
   - {fileID: 11400000, guid: c967bf66a04e87a4187774ae877c0b30, type: 2}
   greenItems:
   - {fileID: 11400000, guid: fd59cfaa2cd3c074181468a238f85a2f, type: 2}
-  - {fileID: 11400000, guid: ecfd4ac6d5d648242b23abe52b4365dd, type: 2}
-  - {fileID: 11400000, guid: 81bcccb955febdc4d8072df86b01c43f, type: 2}
   - {fileID: 11400000, guid: e0b1a6fca06ef204c97de61a549cadef, type: 2}
+  - {fileID: 11400000, guid: 1c6a30a6592c713428957144f453e66c, type: 2}
   redItems:
-  - {fileID: 11400000, guid: ea622d38fbee5f940b71ceae5dc7c189, type: 2}
+  - {fileID: 11400000, guid: 71e49209f061a9141a5b3dae5a4fab3f, type: 2}
   yellowItems:
-  - {fileID: 11400000, guid: 54b0f3210cb3e1b44aab89fc05e0173b, type: 2}
+  - {fileID: 11400000, guid: 023d1050317a4264a815c07474527f0f, type: 2}
   whiteWeight: 80
-  greenWeight: 20
-  redWeight: 0.5
-  yellowWeight: 0.1
+  greenWeight: 40
+  redWeight: 1
+  yellowWeight: 0.5

--- a/Assets/Scripts/Items/Configs/Bat.asset.meta
+++ b/Assets/Scripts/Items/Configs/Bat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3161218f62bb0ea4c92abf623e5d2349
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items/ItemPickup.cs
+++ b/Assets/Scripts/Items/ItemPickup.cs
@@ -54,7 +54,7 @@ public class ItemPickup : MonoBehaviour, IInteractable
 
         var hit = Physics2D.Raycast(transform.position, Vector2.down, 50f, LayerMask.GetMask("Ground"));
         if (hit.collider != null)
-            dropTarget = hit.point.y + 0.3f;
+            dropTarget = hit.point.y + 1f;
         else
             dropTarget = transform.position.y - Random.Range(1f, 2f);
     }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.InputSystem;
 
 public class PlayerMovement : MonoBehaviour
@@ -24,7 +24,8 @@ public class PlayerMovement : MonoBehaviour
     [HideInInspector]
         float movementDirection;
 
-    
+    public void AddJump(byte amount = 1) => chars.maxJumps += amount;
+    public void RemoveJump(byte amount = 1) => chars.maxJumps = (byte)Mathf.Max(1, chars.maxJumps - amount);
 
     private void Start()
     {

--- a/Assets/Sprites/background_objects/items/item_kit.aseprite.meta
+++ b/Assets/Sprites/background_objects/items/item_kit.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 100
+    spritePixelsToUnits: 24
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -72,7 +72,7 @@ ScriptedImporter:
     textureFormatSet: 0
     applyGammaDecoding: 0
   previousAsepriteImporterSettings:
-    fileImportMode: 1
+    fileImportMode: 0
     importHiddenLayers: 0
     layerImportMode: 1
     defaultPivotSpace: 0
@@ -87,7 +87,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   asepriteImporterSettings:
-    fileImportMode: 1
+    fileImportMode: 0
     importHiddenLayers: 0
     layerImportMode: 1
     defaultPivotSpace: 0
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 0
+  platformSettingsDirtyTick: 639128953144985618
   textureAssetName: 
   singleSpriteImportData:
   - name: 
@@ -148,7 +148,70 @@ ScriptedImporter:
     edges: []
     tessellationDetail: 0
     uvTransform: {x: 4, y: 4}
-  spriteSheetImportData: []
+  spriteSheetImportData:
+  - name: item_kit_0
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 20
+      y: 37
+      width: 14
+      height: 11
+    spriteID: b31ba16e4a7668b47afeb4534eb764eb
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
+  - name: item_kit_1
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 36
+      y: 35
+      width: 13
+      height: 15
+    spriteID: d5645e1fa68bde44d91a682723822517
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
+  - name: item_kit_2
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 4
+      y: 4
+      width: 28
+      height: 30
+    spriteID: 95948664bf0f4b740ac60a41b52f5ef6
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
   tileSetImportData: []
   asepriteLayers:
   - layerIndex: 0
@@ -177,7 +240,55 @@ ScriptedImporter:
     tileSetIndex: 0
     parentIndex: -1
   tileSets: []
-  platformSettings: []
+  platformSettings:
+  - name: DefaultTexturePlatform
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Standalone
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Android
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Windows Store Apps
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
   generatePhysicsShape: 0
   secondarySpriteTextures: []
   spritePackingTag: 

--- a/Assets/Sprites/background_objects/items/item_pendant.aseprite.meta
+++ b/Assets/Sprites/background_objects/items/item_pendant.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 100
+    spritePixelsToUnits: 24
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -72,7 +72,7 @@ ScriptedImporter:
     textureFormatSet: 0
     applyGammaDecoding: 0
   previousAsepriteImporterSettings:
-    fileImportMode: 1
+    fileImportMode: 0
     importHiddenLayers: 0
     layerImportMode: 1
     defaultPivotSpace: 0
@@ -87,7 +87,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   asepriteImporterSettings:
-    fileImportMode: 1
+    fileImportMode: 0
     importHiddenLayers: 0
     layerImportMode: 1
     defaultPivotSpace: 0
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 0
+  platformSettingsDirtyTick: 639128953144985618
   textureAssetName: 
   singleSpriteImportData:
   - name: 
@@ -148,7 +148,49 @@ ScriptedImporter:
     edges: []
     tessellationDetail: 0
     uvTransform: {x: 4, y: 4}
-  spriteSheetImportData: []
+  spriteSheetImportData:
+  - name: item_pendant_0
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 21
+      y: 24
+      width: 14
+      height: 13
+    spriteID: e8e2450d78208a54caeb64902f732351
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
+  - name: item_pendant_1
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 4
+      y: 4
+      width: 14
+      height: 13
+    spriteID: b3e493b25770aa941bca75e299ea0e97
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
   tileSetImportData: []
   asepriteLayers:
   - layerIndex: 0
@@ -177,7 +219,55 @@ ScriptedImporter:
     tileSetIndex: 0
     parentIndex: -1
   tileSets: []
-  platformSettings: []
+  platformSettings:
+  - name: DefaultTexturePlatform
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Standalone
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Android
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Windows Store Apps
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
   generatePhysicsShape: 0
   secondarySpriteTextures: []
   spritePackingTag: 

--- a/Assets/Sprites/background_objects/items/item_vampire.aseprite.meta
+++ b/Assets/Sprites/background_objects/items/item_vampire.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 100
+    spritePixelsToUnits: 24
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -72,7 +72,7 @@ ScriptedImporter:
     textureFormatSet: 0
     applyGammaDecoding: 0
   previousAsepriteImporterSettings:
-    fileImportMode: 1
+    fileImportMode: 0
     importHiddenLayers: 0
     layerImportMode: 1
     defaultPivotSpace: 0
@@ -87,7 +87,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   asepriteImporterSettings:
-    fileImportMode: 1
+    fileImportMode: 0
     importHiddenLayers: 0
     layerImportMode: 1
     defaultPivotSpace: 0
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 0
+  platformSettingsDirtyTick: 639128953144985618
   textureAssetName: 
   singleSpriteImportData:
   - name: 
@@ -148,7 +148,49 @@ ScriptedImporter:
     edges: []
     tessellationDetail: 0
     uvTransform: {x: 4, y: 4}
-  spriteSheetImportData: []
+  spriteSheetImportData:
+  - name: item_vampire_0
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 35
+      y: 32
+      width: 13
+      height: 13
+    spriteID: 89cafd43f25ccec49bbeef265cd425b1
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
+  - name: item_vampire_1
+    originalName: 
+    pivot: {x: 0.5, y: 0.5}
+    alignment: 0
+    border: {x: 0, y: 0, z: 0, w: 0}
+    customData: 
+    rect:
+      serializedVersion: 2
+      x: 4
+      y: 4
+      width: 26
+      height: 24
+    spriteID: bbc68b9bb83f34f45a7366d8ce593c01
+    spriteBone: []
+    spriteOutline: []
+    vertices: []
+    spritePhysicsOutline: []
+    indices: 
+    edges: []
+    tessellationDetail: 0
+    uvTransform: {x: 0, y: 0}
   tileSetImportData: []
   asepriteLayers:
   - layerIndex: 0
@@ -177,7 +219,55 @@ ScriptedImporter:
     tileSetIndex: 0
     parentIndex: -1
   tileSets: []
-  platformSettings: []
+  platformSettings:
+  - name: DefaultTexturePlatform
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Standalone
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Android
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
+  - name: Windows Store Apps
+    overridden: 0
+    ignorePlatformSupport: 0
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    androidETC2FallbackOverride: 0
   generatePhysicsShape: 0
   secondarySpriteTextures: []
   spritePackingTag: 

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,12 +3,12 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 6
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
   m_PositionIterations: 3
-  m_VelocityThreshold: 1
+  m_BounceThreshold: 1
   m_MaxLinearCorrection: 0.2
   m_MaxAngularCorrection: 8
   m_MaxTranslationSpeed: 100
@@ -19,6 +19,7 @@ Physics2DSettings:
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
   m_DefaultContactOffset: 0.01
+  m_ContactThreshold: 0
   m_JobOptions:
     serializedVersion: 2
     useMultithreading: 0
@@ -39,18 +40,17 @@ Physics2DSettings:
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
   m_SimulationMode: 0
+  m_SimulationLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxSubStepCount: 4
+  m_MinSubStepFPS: 30
+  m_UseSubStepping: 0
+  m_UseSubStepContacts: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0
-  m_AlwaysShowColliders: 0
-  m_ShowColliderSleep: 1
-  m_ShowColliderContacts: 0
-  m_ShowColliderAABB: 0
-  m_ContactArrowScale: 0.2
-  m_ColliderAwakeColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.7529412}
-  m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
-  m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
-  m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_GizmoOptions: 10
+  m_LayerCollisionMatrix: fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
Add ExtraJumpEffect script and WingsEffect prefab plus a Wings item that grant an extra jump. Add Bat drop config and update Scientist1 drop list. Update item prefabs to reference icons where available. Increase PlayerMeleeAttack hitbox size and adjust offset. Change ItemPickup drop target height so items appear higher when spawned. Add AddJump/RemoveJump methods to PlayerMovement and clamp maxJumps on removal. Update Aseprite importer settings (pixels-per-unit, sprite sheet frames and platform settings) for several item sprites. Update Physics2DSettings serialized version, simulation layers and gizmo/collision matrix entries.