### PR TITLE
TestScene: add EntityCost and clean up scene

### DIFF
--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -987,6 +987,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyLogicRat
   _name: "\u043A\u0440\u044B\u0441\u0430"
+  EntityCost: 10
   stats:
     speed: 5
     attackPower: 1
@@ -1601,80 +1602,6 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!1001 &413602931
 PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7943887161465075861, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_Name
-      value: Debris (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 30.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
---- !u!1 &414914553
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 414914554}
-  - component: {fileID: 414914555}
-  m_Layer: 0
-  m_Name: Circle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &414914554
-Transform:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
@@ -4297,76 +4224,19 @@ PrefabInstance:
 --- !u!1 &871514479
 GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7943887161465075861, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_Name
-      value: Debris (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 8.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 30.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
---- !u!1 &871514479
-GameObject:
-  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 871514482}
-  - component: {fileID: 871514481}
   - component: {fileID: 871514480}
+  - component: {fileID: 871514481}
   - component: {fileID: 871514483}
   - component: {fileID: 871514484}
   m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
+  m_Name: MainCamera
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -8293,73 +8163,16 @@ PrefabInstance:
 --- !u!1 &1621454017
 GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7943887161465075861, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_Name
-      value: Debris (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 14.77
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8085106209963422471, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 83f5d3c57f58a194c9db67095cf499f7, type: 3}
---- !u!1 &1621454017
-GameObject:
-  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1621454020}
-  - component: {fileID: 1621454019}
   - component: {fileID: 1621454018}
+  - component: {fileID: 1621454019}
   m_Layer: 0
-  m_Name: EventSystem
+  m_Name: InputManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -10748,10 +10561,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: df2d69e2a5bdc564499ee05f7f9703b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CameraManager
-  defaultCamera: {fileID: 0}
-  allCameras: []
-  currentCamera: {fileID: 0}
-  player: {fileID: 0}
 --- !u!114 &4214717406839767300
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Add EntityCost: 10 to the EnemyLogicRat MonoBehaviour and tidy the scene file by removing numerous prefab-instance modification blocks (reducing serialized override clutter). Also normalize object names/tags: rename "Main Camera" to "MainCamera" and set its tag to Untagged, rename "EventSystem" to "InputManager", adjust component ordering, and remove unused CameraManager serialized references (defaultCamera, allCameras, currentCamera, player). These changes clean up the scene serialization and fix naming/metadata inconsistencies.