### PR TITLE
Adjust UI font sizes and difficulty scaling

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -2913,7 +2913,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 250
+  m_fontSize: 217.3
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -4193,8 +4193,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DifficultyManager
   <DifficultyMultiplier>k__BackingField: 1
-  IntervalSeconds: 120
-  MultiplierIncrease: 0.15
+  IntervalSeconds: 150
+  MultiplierIncrease: 0.065
 --- !u!4 &776451923
 Transform:
   m_ObjectHideFlags: 0
@@ -6396,7 +6396,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 41.7
+  m_fontSize: 31.75
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6706,7 +6706,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 67.2
+  m_fontSize: 60
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -11321,7 +11321,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 41.35
+  m_fontSize: 31.5
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1


### PR DESCRIPTION
Update MainMenu scene: reduce several TextMeshPro m_fontSize values for UI elements (250→217.3, 41.7→31.75, 67.2→60, 41.35→31.5) to improve layout/legibility. Tweak DifficultyManager parameters to slow progression (IntervalSeconds 120→150, MultiplierIncrease 0.15→0.065).