### PR TITLE
Increase parry window duration

### DIFF
--- a/Assets/Scenes/BossBattle.unity
+++ b/Assets/Scenes/BossBattle.unity
@@ -2166,7 +2166,7 @@ MonoBehaviour:
   bounceForceY: 5
   counterAttackDistance: 3
   counterAttackDamage: 10
-  parryWindowDuration: 0.18
+  parryWindowDuration: 0.25
   hintCanvasGroup: {fileID: 1195556178}
   hintBackground: {fileID: 749771499}
   maxPoise: 100


### PR DESCRIPTION
Raise parryWindowDuration in BossBattle.unity from 0.18s to 0.25s to give players a slightly larger timing window for parries during the boss fight.